### PR TITLE
Disallow multiple spaces inside a line

### DIFF
--- a/__tests__/es2017.spec.js
+++ b/__tests__/es2017.spec.js
@@ -16,6 +16,6 @@ describe('ES 2017', () => {
     const code = getFixture('es2017/invalid.js');
     const result = runLinter(code, 'index');
 
-    t.equal(result.errorCount, 6);
+    t.equal(result.errorCount, 8);
   });
 });

--- a/__tests__/es5.spec.js
+++ b/__tests__/es5.spec.js
@@ -16,6 +16,6 @@ describe('ES 5', () => {
     const code = getFixture('es5/invalid.js');
     const result = runLinter(code, 'es5');
 
-    t.equal(result.errorCount, 14);
+    t.equal(result.errorCount, 16);
   });
 });

--- a/__tests__/fixtures/es2017/invalid.js
+++ b/__tests__/fixtures/es2017/invalid.js
@@ -3,5 +3,8 @@ function a() {
   return 2;
 }
 
+import     React from   'react';
+
+console.log(React);
 
 const b = (t) => t+2;

--- a/__tests__/fixtures/es5/invalid.js
+++ b/__tests__/fixtures/es5/invalid.js
@@ -17,6 +17,8 @@ function b(t) {
   return typeof t !== 'undefined' ? true : false;
 }
 
+console.log(   b(  "s"   )); // eslint-disable-line no-console
+
 /*
  asdsf
 */

--- a/rules/base.js
+++ b/rules/base.js
@@ -37,6 +37,7 @@ module.exports = {
       "requireReturn": false,
       "requireReturnDescription": false,
       "requireParamDescription": false
-    }]
+    }],
+    "no-multi-spaces": "error"
   }
 };


### PR DESCRIPTION
Disallows superfluous spacing:

``` js
import      React   from    'react';
```
