### PR TITLE
Update eslint-plugin-react to version 7.1.0

### DIFF
--- a/__tests__/fixtures/react/invalid.js
+++ b/__tests__/fixtures/react/invalid.js
@@ -3,6 +3,7 @@
  * to eschew the "id" and "for" unless you want to employ some very hacky solutions
  */
 import React  from  'react';
+import PropTypes from 'prop-types';
 import styles from './styles.css';
 
 class Accordion extends React.Component {
@@ -18,7 +19,7 @@ class Accordion extends React.Component {
   }
 }
 
-const { number, string } = React.PropTypes;
+const { number, string } = PropTypes;
 
 Accordion.propTypes = {
   label: string,

--- a/__tests__/fixtures/react/valid.js
+++ b/__tests__/fixtures/react/valid.js
@@ -3,6 +3,7 @@
  * to eschew the "id" and "for" unless you want to employ some very hacky solutions
  */
 import React from 'react';
+import PropTypes from 'prop-types';
 import styles from './styles.css';
 
 const Accordion = ({ name, value, checked, label, children }) => {
@@ -16,7 +17,7 @@ const Accordion = ({ name, value, checked, label, children }) => {
   );
 };
 
-const { number, string } = React.PropTypes;
+const { number, string } = PropTypes;
 
 Accordion.propTypes = {
   label: string,

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
   },
   "dependencies": {
     "babel-eslint": "^7.1.1",
-    "eslint-plugin-react": "^6.9.0"
+    "eslint-plugin-react": "^7.1.0"
   }
 }


### PR DESCRIPTION
Should fix wrong linter warnings for no-used-prop-types
https://github.com/yannickcr/eslint-plugin-react/pull/1106